### PR TITLE
Fix: Parsing b64-encoded credentials containing column in password

### DIFF
--- a/ray2sing/shadowsocks.go
+++ b/ray2sing/shadowsocks.go
@@ -19,7 +19,7 @@ func parseShadowsocks(configStr string) (map[string]string, error) {
 		password, _ = parsedURL.User.Password()
 	} else {
 		// If decoding is successful, use the decoded string
-		userDetails := strings.Split(userInfo, ":")
+		userDetails := strings.SplitN(userInfo, ":", 2)
 		encryption_method = userDetails[0]
 		password = userDetails[1]
 	}

--- a/ray2sing/url_schema.go
+++ b/ray2sing/url_schema.go
@@ -51,7 +51,7 @@ func ParseUrl(inputURL string) (*UrlSchema, error) {
 	// fmt.Print(userInfo)
 	if err == nil {
 		// If decoding is successful, use the decoded string
-		userDetails := strings.Split(userInfo, ":")
+		userDetails := strings.SplitN(userInfo, ":", 2)
 		if len(userDetails) > 1 {
 			data.Username = userDetails[0]
 			data.Password = userDetails[1]

--- a/ray2sing_test/shadowsocks_test.go
+++ b/ray2sing_test/shadowsocks_test.go
@@ -27,3 +27,54 @@ func TestShadowsocks(t *testing.T) {
 	`
 	ray2sing.CheckUrlAndJson(url, expectedJSON, t)
 }
+
+
+func TestShadowsocksEIHBase64(t *testing.T) {
+	// EIH extension: https://github.com/Shadowsocks-NET/shadowsocks-specs/blob/main/2022-2-shadowsocks-2022-extensible-identity-headers.md
+	// Named as "multi-user" in https://sing-box.sagernet.org/configuration/inbound/shadowsocks/#structure
+
+	url := "ss://MjAyMi1ibGFrZTMtYWVzLTEyOC1nY206cTdENzRBVjhCRlY0UUk3NWVqVS9nTXViWER4ejEyRysvU2o3RUlyTHZCdz06L21JTjIvb0pZRzBJbHZGYlA1UEs5VmhGcnlTODl0ZjFEK3E4SUR1czA0VT0%3D@10.20.30.40:54321#sample-tag"
+	// b64decode(MjAyMi1...) = "2022-blake3-aes-128-gcm:q7D74AV8BFV4QI75ejU/gMubXDxz12G+/Sj7EIrLvBw=:/mIN2/oJYG0IlvFbP5PK9VhFryS89tf1D+q8IDus04U="
+
+	expectedJSON := `
+	{
+		"outbounds": [
+		  {
+			"type": "shadowsocks",
+			"tag": "sample-tag § 0",
+			"server": "10.20.30.40",
+			"server_port": 54321,
+			"method": "2022-blake3-aes-128-gcm",
+			"password": "q7D74AV8BFV4QI75ejU/gMubXDxz12G+/Sj7EIrLvBw=:/mIN2/oJYG0IlvFbP5PK9VhFryS89tf1D+q8IDus04U="
+		  }
+		]
+	  }
+	`
+
+	ray2sing.CheckUrlAndJson(url, expectedJSON, t)
+}
+
+
+func TestShadowsocksEIHPlain(t *testing.T) {
+	// EIH extension: https://github.com/Shadowsocks-NET/shadowsocks-specs/blob/main/2022-2-shadowsocks-2022-extensible-identity-headers.md
+	// Named as "multi-user" in https://sing-box.sagernet.org/configuration/inbound/shadowsocks/#structure
+
+	url := "ss://2022-blake3-aes-128-gcm:q7D74AV8BFV4QI75ejU%2FgMubXDxz12G%2B%2FSj7EIrLvBw%3D:%2FmIN2%2FoJYG0IlvFbP5PK9VhFryS89tf1D%2Bq8IDus04U%3D@10.20.30.40:54321#sample-tag"
+
+	expectedJSON := `
+	{
+		"outbounds": [
+		  {
+			"type": "shadowsocks",
+			"tag": "sample-tag § 0",
+			"server": "10.20.30.40",
+			"server_port": 54321,
+			"method": "2022-blake3-aes-128-gcm",
+			"password": "q7D74AV8BFV4QI75ejU/gMubXDxz12G+/Sj7EIrLvBw=:/mIN2/oJYG0IlvFbP5PK9VhFryS89tf1D+q8IDus04U="
+		  }
+		]
+	  }
+	`
+
+	ray2sing.CheckUrlAndJson(url, expectedJSON, t)
+}


### PR DESCRIPTION
Shadowsocks 2022 has an [EIH extension](https://github.com/Shadowsocks-NET/shadowsocks-specs/blob/main/2022-2-shadowsocks-2022-extensible-identity-headers.md) allowing using different encryption keys for different users. 

These keys are supposed to be provided together with the shared server keys separated by columns. So the url looks like `ss://{encryption}:{server_key}:{user_key}@{ip}:{port}/#{tag}`. The part before `@` is supposed to be plain-text for AEAD-2022 urls, but some servers (e.g., X-UI) are encoding it in base64.

Currently, the `ray2sing` incorrectly parses urls with EIH keys and base64-encoded. Specifically, it dropx the user key completely.

This PR fixes such parsing, by replacing `Split` method with `SplitN`, so the auth string is split onto no more than two parts.

