### PR TITLE
Fix Vmess

### DIFF
--- a/ray2sing/convert.go
+++ b/ray2sing/convert.go
@@ -52,8 +52,8 @@ var xrayConfigTypes = map[string]ParserFunc{
 func decodeUrlBase64IfNeeded(config string) string {
 	splt := strings.SplitN(config, "://", 2)
 
-	rest, err := decodeBase64IfNeeded(splt[1])
-	fmt.Println(rest, err)
+	rest, _ := decodeBase64IfNeeded(splt[1])
+	// fmt.Println(rest, err)
 	return splt[0] + "://" + rest
 }
 


### PR DESCRIPTION
Removes the debug `fmt.Println` in `decodeUrlBase64IfNeeded` to clean up the output of the `convert` command.